### PR TITLE
Add passport req.logIn

### DIFF
--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -18,7 +18,12 @@ router.post('/login', authHelpers.loginRedirect, (req, res, next) => {
   passport.authenticate('local', (err, user, info) => {
     if (err) { handleResponse(res, 500, 'error'); }
     if (!user) { handleResponse(res, 404, 'User not found'); }
-    if (user) { handleResponse(res, 200, 'success'); }
+    if (user) {
+      req.logIn(user, function (err) {
+        if (err) { handleResponse(res, 500, 'error'); }
+        handleResponse(res, 200, 'success');
+      });
+    }
   })(req, res, next);
 });
 


### PR DESCRIPTION
Addresses #1

In the custom callback section of the Passport docs: "The callback can
use the arguments supplied to handle the authentication result as
desired. Note that when using a custom callback, it becomes the
application's responsibility to establish a session (by calling
req.login()) and send a response."

Sessions don't appear to work as currently implemented, this adds the
req.logIn function.